### PR TITLE
Configuração básica da documentação Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # fiap-hexagonal-architecture
-Projeto prático desenvolvido durante a Postech Software Architecture
+Projeto prático desenvolvido durante a Postech FIAP (Software Architecture).
 
-# TODO
-* [ ] Cliente
-  * [ ] Cadastro do cliente (ID, nome, CPF)
-  * [ ] Consulta via CPF
-* [ ] Produto
-  * [ ] Criação
-  * [ ] Edição
-  * [ ] Remoção
-  * [ ] Buscar por categoria
-* [ ] Checkout (fake)
-* [ ] Pedidos
-  * [ ] Listar
+## Documentação da API
+
+A documentação da API foi gerada a partir da utilização da biblioteca [Springdoc (OpenAPI)](https://springdoc.org/).
+
+Após iniciar a aplicação, a documentação pode ser acessada através do endereço:
+
+http://localhost:8080/swagger-ui/index.html
+

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 

--- a/src/main/java/com/fiap/restaurant/BeanConfiguration.java
+++ b/src/main/java/com/fiap/restaurant/BeanConfiguration.java
@@ -12,6 +12,8 @@ import com.fiap.restaurant.core.service.order.ItemService;
 import com.fiap.restaurant.core.service.order.OrderService;
 import com.fiap.restaurant.core.service.product.ImageService;
 import com.fiap.restaurant.core.service.product.ProductService;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,5 +67,14 @@ public class BeanConfiguration {
     @Bean
     public ImageService imageService() {
         return new ImageService(this.imageRepository);
+    }
+
+    @Bean
+    public OpenAPI api() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Tech Challenge - FIAP")
+                        .description("Documentação da API utilizada na construção da solução ao desafio técnico proposto na Postech FIAP (Software Architecture)")
+                        .version("1.0"));
     }
 }


### PR DESCRIPTION
Havíamos falado em utilizar a biblioteca SpringFox para providenciar, a partir do código, a documentação Swagger da API. Contudo, essa biblioteca não oferece suporte à versão Spring Boot 3, conforme algumas [issues](https://github.com/springfox/springfox/issues/4041).

Assim, explorei outra alternativa utilizando a biblioteca [Springdoc (OpenAPI)](https://springdoc.org/).

Dessa forma, esse PR tem por objetivo disponibilizar a configuração básica da biblioteca no projeto, gerando a documentação a partir do código implementado.

Após iniciar a aplicação, a documentação pode ser acessada através do endereço:
http://localhost:8080/swagger-ui/index.html

**Questão identificada:**
Por estarmos usando os __models__ da camada core como entrada dos _endpoints_, é possível perceber um ponto duvidoso no processo de execução do _endpoint_ a partir da documentação.
Tomando como exemplo o _endpoint_ de criação de clientes, o _payload_ sugerido solicita o atributo `id`. Porém, esse atributo será gerado no _backend_ e o valor atualizado será retornado para o usuário no corpo da resposta. Essa situação não acarreta em erro.

![customer-controller](https://github.com/richardaltmayer/fiap-hexagonal-architecture/assets/10313123/f078a9af-a147-44bc-9d44-87fb66819499)


Talvez seja interessante considerarmos o uso de DTOs para encapsular o modelo de entrada dos _endpoints_. Contudo, não sei se conseguiremos adotar esse padrão ainda para a fase 1 do trabalho.