### PR TITLE
[Clean Architecture] Item findById

### DIFF
--- a/src/main/java/com/fiap/restaurant/cleanarchitecture/external/db/order/ItemJpaConnection.java
+++ b/src/main/java/com/fiap/restaurant/cleanarchitecture/external/db/order/ItemJpaConnection.java
@@ -3,6 +3,8 @@ package com.fiap.restaurant.cleanarchitecture.external.db.order;
 import com.fiap.restaurant.cleanarchitecture.types.interfaces.db.order.ItemDatabaseConnection;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class ItemJpaConnection implements ItemDatabaseConnection<ItemJpa> {
 
@@ -18,8 +20,8 @@ public class ItemJpaConnection implements ItemDatabaseConnection<ItemJpa> {
     }
 
     @Override
-    public ItemJpa getById(Long id) {
-        return this.itemJpaRepository.getReferenceById(id);
+    public Optional<ItemJpa> getById(Long id) {
+        return this.itemJpaRepository.findById(id);
     }
 
     @Override

--- a/src/main/java/com/fiap/restaurant/cleanarchitecture/gateway/order/ItemProductGateway.java
+++ b/src/main/java/com/fiap/restaurant/cleanarchitecture/gateway/order/ItemProductGateway.java
@@ -10,6 +10,7 @@ import com.fiap.restaurant.cleanarchitecture.types.interfaces.db.product.Product
 import com.fiap.restaurant.cleanarchitecture.types.mapper.order.ItemProductMapper;
 
 import java.util.List;
+import java.util.Optional;
 
 @SuppressWarnings("unchecked")
 public class ItemProductGateway implements IItemProductGateway {
@@ -26,12 +27,12 @@ public class ItemProductGateway implements IItemProductGateway {
 
     @Override
     public ItemProduct save(ItemProduct itemProduct) {
-        ProductJpa productJpa = (ProductJpa) productDatabaseConnection.getById(itemProduct.getProduct().getId());
-        ItemJpa itemJpa = (ItemJpa) itemDatabaseConnection.getById(itemProduct.getItem().getId());
+        Optional<ProductJpa> productJpa = productDatabaseConnection.getById(itemProduct.getProduct().getId());
+        Optional<ItemJpa> itemJpa = itemDatabaseConnection.getById(itemProduct.getItem().getId());
 
         ItemProductJpa itemProductJpa = new ItemProductJpa();
-        itemProductJpa.setProduct(productJpa);
-        itemProductJpa.setItem(itemJpa);
+        itemProductJpa.setProduct(productJpa.get());
+        itemProductJpa.setItem(itemJpa.get());
 
         itemProductJpa = (ItemProductJpa) this.itemProductDatabaseConnection.save(itemProductJpa);
 

--- a/src/main/java/com/fiap/restaurant/cleanarchitecture/types/interfaces/db/order/ItemDatabaseConnection.java
+++ b/src/main/java/com/fiap/restaurant/cleanarchitecture/types/interfaces/db/order/ItemDatabaseConnection.java
@@ -1,9 +1,11 @@
 package com.fiap.restaurant.cleanarchitecture.types.interfaces.db.order;
 
+import java.util.Optional;
+
 public interface ItemDatabaseConnection<T> {
 
     T save(T itemProduct);
-    T getById(Long id);
+    Optional<T> getById(Long id);
     void delete(Long id);
     boolean existsById(Long id);
 }


### PR DESCRIPTION
Esse PR tem por objetivo padronizar as operações de consulta sobre `Item`, deixando de fazer uso do método JPA `getReferenceById`, que retorna um proxy do objeto, o que estava causando erro na hora de processar alterações nos objetos.