### PR TITLE
[K8S] LoadBalancer considera apenas Nodes e não Pods

### DIFF
--- a/k8s-app.yaml
+++ b/k8s-app.yaml
@@ -11,6 +11,7 @@ spec:
       protocol: TCP
       nodePort: 30000
   type: LoadBalancer
+  externalTrafficPolicy: Local
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Essa configuração ajuda a preservar o IP original do cliente em troca de um possível desbalanceamento de carga em cenários que houver mais de um node.